### PR TITLE
Allow the user to override dispose behavior

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -197,6 +197,7 @@ function WebRtcPeer(mode, options, callback) {
   var remoteVideo = options.remoteVideo
   var videoStream = options.videoStream
   var audioStream = options.audioStream
+  var ondispose = options.ondispose
   var mediaConstraints = options.mediaConstraints
 
   var connectionConstraints = options.connectionConstraints
@@ -623,17 +624,21 @@ function WebRtcPeer(mode, options, callback) {
   }
 
   this.on('_dispose', function () {
-    if (localVideo) {
-      localVideo.pause()
-      localVideo.src = ''
-      localVideo.load()
+    if (ondispose) {
+      ondispose()
+    } else {
+      if (localVideo) {
+        localVideo.pause()
+        localVideo.src = ''
+        localVideo.load()
         //Unmute local video in case the video tag is later used for remote video
-      localVideo.muted = false
-    }
-    if (remoteVideo) {
-      remoteVideo.pause()
-      remoteVideo.src = ''
-      remoteVideo.load()
+        localVideo.muted = false
+      }
+      if (remoteVideo) {
+        remoteVideo.pause()
+        remoteVideo.src = ''
+        remoteVideo.load()
+      }
     }
     self.removeAllListeners()
 


### PR DESCRIPTION
Hello guys.

Here is a little feature that allow the user to change the behavior of dispose process.

### Motivation

Firefox behavior on `video.src = ""` is loading the current page and throw error. But the clearing of the src of the video on dispose is a good behavior... In most cases. So what to do ?

### Why this solution ?

There's currently no way to change this behavior that could generate unwanted behaviors in firefox because the event dispatcher is not available as external feature of kurento utils lib. That's why I added a dispose callback.


**What do you think about ?** Maybe just change the behavior is a better idea ? (but for what ?)