### PR TITLE
Fix RTCOfferOptions logic to be more compatible

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -384,8 +384,8 @@ function WebRtcPeer(mode, options, callback) {
         mediaConstraints.video : true
     }
 
-    var browserDependantConstraints = (browser.name === 'Firefox' &&
-      browser.version > 34) ? {
+    var browserDependantConstraints = !(browser.name === 'Firefox' &&
+      browser.version <= 34) ? {
       offerToReceiveAudio: (mode !== 'sendonly' && offerAudio),
       offerToReceiveVideo: (mode !== 'sendonly' && offerVideo)
     } : {


### PR DESCRIPTION
The mandatory / option style options is supported in Chrome and older versions of Firefox, the other format is more widely supported.

Note: the these options are being replaced with a new concept of "Transceivers" at some point in the future.