### PR TITLE
support Safari 11

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -425,18 +425,17 @@ function WebRtcPeer(mode, options, callback) {
   function setRemoteVideo() {
     if (remoteVideo) {
       var stream = pc.getRemoteStreams()[0]
-      var url = stream ? URL.createObjectURL(stream) : ''
 
       remoteVideo.pause()
-      remoteVideo.src = url
+      remoteVideo.srcObject = stream
       remoteVideo.load()
 
-      logger.info('Remote URL:', url)
+      logger.info('Remote URL:', remoteVideo.srcObject)
     }
   }
 
   this.showLocalVideo = function () {
-    localVideo.src = URL.createObjectURL(videoStream)
+    localVideo.srcObject = videoStream
     localVideo.muted = true
   }
 


### PR DESCRIPTION
Switch from HTMLMediaElement.src to HTMLMediaElement.srcObject when assiging streams to local/remote video elements to support Safari 11.
Tested with Safari 11 on iPad with the latest iOS 11 beta and MacOS High Sierra with the latest version of beta as of Sep 17, 2017.
Both worked with no issues.
Notes: 
* I verified that all major browsers have introduced .srcObject at least a few releases before supporting WebRTC, so I found no need to create a shim for .srcObject for older browsers.
* My tests are with an audio-only setup. There might be other issues related to video RT streaming that I didn't catch, but I have verified that this change works with the latest KMS for audio RT streaming and that cross-browsers (Chrome and FireFox) audio mixing works against Safari 11 on both iOS and MacOS.