### PR TITLE
Apply connectionConstraints

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -283,7 +283,7 @@ function WebRtcPeer(mode, options, callback) {
 
   // Init PeerConnection
   if (!pc) {
-    pc = new RTCPeerConnection(configuration);
+    pc = new RTCPeerConnection(configuration, connectionConstraints);
     if (useDataChannels && !dataChannel) {
       var dcId = 'WebRtcPeer-' + self.id
       var dcOptions = undefined


### PR DESCRIPTION
Refer to http://doc-kurento.readthedocs.io/en/stable/mastering/kurento_utils_js.html

> connectionConstraints: Defined the connection constraint according with browser like googIPv6, DtlsSrtpKeyAgreement...

Yet, it never be used. I apply it to 
`pc = new RTCPeerConnection(configuration, connectionConstraints);`

example constraints object from Hangout
`connectionConstraints: {
                    mandatory: {
                        // DtlsSrtpKeyAgreement: false,
                        // RtpDataChannels: true,
                    },
                    optional: [
                        { googDscp: true },
                        { googCpuOveruseDetection: true },
                        { googCpuOveruseEncodeUsage: true },
                        { googCpuUnderuseThreshold: 55 },
                        { googCpuOveruseThreshold: 85 },
                        { googScreencastMinBitrate: 400 },
                        { googHighStartBitrate: 0 },
                        { googPayloadPadding: true },
                        // { googCombinedAudioVideoBwe: true }
                    ]
                }`

Result from chrome://webrtc-internals
> { iceServers: [stun:stun.voiparound.com, stun:stun2.l.google.com:19302], iceTransportPolicy: all, bundlePolicy: balanced, rtcpMuxPolicy: require, iceCandidatePoolSize: 0 }, {advanced: [{enableDscp: {exact: true}}, {googCpuOveruseDetection: {exact: true}}, {googCpuOveruseEncodeUsage: {exact: true}}, {googCpuUnderuseThreshold: {exact: 55}}, {googCpuOveruseThreshold: {exact: 85}}, {googScreencastMinBitrate: {exact: 400}}, {googHighStartBitrate: {exact: 0}}, {googPayloadPadding: {exact: true}}]}