### PR TITLE
Updating uuid to 3.2.1 version

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -17,7 +17,7 @@
 var freeice = require('freeice')
 var inherits = require('inherits')
 var UAParser = require('ua-parser-js')
-var uuid = require('uuid')
+var uuidv4 = require('uuid/v4')
 var hark = require('hark')
 
 var EventEmitter = require('events').EventEmitter
@@ -207,7 +207,7 @@ function WebRtcPeer(mode, options, callback) {
   var useDataChannels = options.dataChannels || false
   var dataChannel
 
-  var guid = uuid.v4()
+  var guid = uuidv4()
   var configuration = recursive({
       iceServers: freeice()
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "merge": "^1.2.0",
     "sdp-translator": "^0.1.15",
     "ua-parser-js": "^0.7.7",
-    "uuid": "~3.2.1"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "bower": "~1.7.9",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "merge": "^1.2.0",
     "sdp-translator": "^0.1.15",
     "ua-parser-js": "^0.7.7",
-    "uuid": "~2.0.1"
+    "uuid": "~3.2.1"
   },
   "devDependencies": {
     "bower": "~1.7.9",


### PR DESCRIPTION
Updating to latest version of uuid was needed in order to make kurento-utils work with angular 6 (webpack 4).

With uuid 2.0.1 the angular app was not starting and showing the error:
_referenceerror: global is not defined at rng-browser.js_
