### PR TITLE
Fix stream checking

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -353,7 +353,7 @@ function WebRtcPeer(mode, options, callback) {
       }
     }
   }
-  if (!pc.getLocalStreams && pc.getSenders) {
+  if ((!pc.getLocalStreams || pc.getLocalStreams().length == 0) && pc.getSenders()) {
     pc.getLocalStreams = function () {
       var stream = new MediaStream();
       pc.getSenders().forEach(function (sender) {
@@ -362,7 +362,7 @@ function WebRtcPeer(mode, options, callback) {
       return [stream];
     };
   }
-  if (!pc.getRemoteStreams && pc.getReceivers) {
+  if ((!pc.getRemoteStreams || pc.getRemoteStreams().length == 0) && pc.getReceivers()) {
     pc.getRemoteStreams = function () {
       var stream = new MediaStream();
       pc.getReceivers().forEach(function (sender) {

--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -353,7 +353,7 @@ function WebRtcPeer(mode, options, callback) {
       }
     }
   }
-  if ((!pc.getLocalStreams || pc.getLocalStreams().length == 0) && pc.getSenders()) {
+  if ((!pc.getLocalStreams() || pc.getLocalStreams().length == 0) && pc.getSenders()) {
     pc.getLocalStreams = function () {
       var stream = new MediaStream();
       pc.getSenders().forEach(function (sender) {
@@ -362,7 +362,7 @@ function WebRtcPeer(mode, options, callback) {
       return [stream];
     };
   }
-  if ((!pc.getRemoteStreams || pc.getRemoteStreams().length == 0) && pc.getReceivers()) {
+  if ((!pc.getRemoteStreams() || pc.getRemoteStreams().length == 0) && pc.getReceivers()) {
     pc.getRemoteStreams = function () {
       var stream = new MediaStream();
       pc.getReceivers().forEach(function (sender) {


### PR DESCRIPTION
On Safari 12 the pc.getLocalStreams and pc.getRemoteStreams are not undefined, just returns with an empty array. 