### PR TITLE
Refactor deprecated syntax

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -596,12 +596,11 @@ function WebRtcPeer(mode, options, callback) {
       return callback('PeerConnection is closed')
     }
 
-    pc.setRemoteDescription(answer, function () {
+    pc.setRemoteDescription(answer).then(function () {
         setRemoteVideo()
 
         callback()
-      },
-      callback)
+    }).catch(callback)
   }
 
   /**


### PR DESCRIPTION
The below syntax is deprecated and it doesn't also work on Safari 12.
```
pc.setRemoteDescription(sessionDescription, successCallback, errorCallback);
```
You can check it here: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setRemoteDescription