### PR TITLE
Fix promise call in setDescription to make compatible with safari

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -132,21 +132,21 @@ function bufferizeCandidates(pc, onerror) {
   return function (candidate, callback) {
     callback = callback || onerror;
     switch (pc.signalingState) {
-      case 'closed':
-        callback(new Error('PeerConnection object is closed'));
+    case 'closed':
+      callback(new Error('PeerConnection object is closed'));
+      break;
+    case 'stable':
+      if (pc.remoteDescription) {
+        pc.addIceCandidate(candidate, callback, callback);
         break;
-      case 'stable':
-        if (pc.remoteDescription) {
-          pc.addIceCandidate(candidate, callback, callback);
-          break;
 
-        }
-        default:
-          candidatesQueue.push({
-            candidate: candidate,
-            callback: callback
+      }
+      default:
+        candidatesQueue.push({
+          candidate: candidate,
+          callback: callback
 
-          });
+        });
     }
   };
 }

--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -132,21 +132,21 @@ function bufferizeCandidates(pc, onerror) {
   return function (candidate, callback) {
     callback = callback || onerror;
     switch (pc.signalingState) {
-    case 'closed':
-      callback(new Error('PeerConnection object is closed'));
-      break;
-    case 'stable':
-      if (pc.remoteDescription) {
-        pc.addIceCandidate(candidate, callback, callback);
+      case 'closed':
+        callback(new Error('PeerConnection object is closed'));
         break;
+      case 'stable':
+        if (pc.remoteDescription) {
+          pc.addIceCandidate(candidate, callback, callback);
+          break;
 
-      }
-      default:
-        candidatesQueue.push({
-          candidate: candidate,
-          callback: callback
+        }
+        default:
+          candidatesQueue.push({
+            candidate: candidate,
+            callback: callback
 
-        });
+          });
     }
   };
 }
@@ -599,7 +599,7 @@ function WebRtcPeer(mode, options, callback) {
       return callback('PeerConnection is closed')
     }
 
-    pc.setRemoteDescription(answer, function () {
+    pc.setRemoteDescription(answer).then(function () {
         setRemoteVideo()
 
         callback()


### PR DESCRIPTION
Fix a little bug that makes safari never receive the stream, we change the promise call to able compatible with safari.

Tested on Safari 13.1 and chrome 81. 
MacOs Catalina (10.15.4) 

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [ x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [ x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
