### PR TITLE
fix: default constaints not working

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -39,7 +39,7 @@ try {
 }
 
 var MEDIA_CONSTRAINTS = {
-  audio: true,
+  audio: false,
   video: {
     width: 640,
     framerate: 15


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->
This is not a PR, but more like an issue. Could not raise an issue from your repo.

## What is the current behavior you want to change?
The default constraints are failing due to 
![Screenshot_2020-11-24_15-44-43](https://user-images.githubusercontent.com/16836510/100089996-8ce98700-2e78-11eb-9176-ccd7c5c9d52d.png)
DomException Could not start the audio source

Tested In Manjaro Latest, Chrome (Brave) 86
